### PR TITLE
fix(web/backend): add `nameNormalized` property

### DIFF
--- a/web/backend/src/routes/firewall.ts
+++ b/web/backend/src/routes/firewall.ts
@@ -18,7 +18,7 @@ firewallRoute.get("/", async (req, res) => {
 
     const parsedFirewallService = {
       chain: firewallService.chain,
-      name: firewallService.name,
+      name: firewallService.nameNormalized,
       nfq: parseInt(firewallService.nfq),
       port: parseInt(firewallService.port),
       protocol: firewallService.protocol as "tcp" | "udp",

--- a/web/backend/src/routes/services.ts
+++ b/web/backend/src/routes/services.ts
@@ -4,6 +4,7 @@ import { Database } from "../database/db"
 import setupMiddleware from "../middlewares/setup"
 import { cerberoEventEmitter } from "../socket/socket"
 import type { CerberoService } from "../types/service"
+import { normalizeName } from "../utils/strings"
 
 const servicesRoute = Router()
 
@@ -118,9 +119,12 @@ servicesRoute.post("/", async (req, res) => {
       await redis.sAdd(`regexes:${service.nfq}:active`, service.regexes)
     }
 
+    const nameNormalized = normalizeName(service.name)
+
     const newService = {
       chain: service.chain,
       name: service.name,
+      nameNormalized: nameNormalized,
       nfq: service.nfq,
       port: service.port,
       protocol: service.protocol

--- a/web/backend/src/socket/socket.ts
+++ b/web/backend/src/socket/socket.ts
@@ -22,7 +22,7 @@ export async function buildConfiguration() {
 
     config.push({
       chain: service.chain,
-      name: service.name,
+      name: service.nameNormalized,
       nfq: parseInt(service.nfq),
       port: parseInt(service.port),
       protocol: service.protocol as "tcp" | "udp",

--- a/web/backend/src/utils/strings.ts
+++ b/web/backend/src/utils/strings.ts
@@ -1,0 +1,7 @@
+export function normalizeName(name: string) {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+}
+


### PR DESCRIPTION
Use a standard format for the name of the services when communicating with the firewall (only lowercase letters, numbers and underscores)

Closes #40