### PR TITLE
Change docker ports setup

### DIFF
--- a/web/docker-compose.yml
+++ b/web/docker-compose.yml
@@ -16,8 +16,7 @@ services:
       cerbero-redis-stack:
         condition: service_healthy
     ports:
-      - 8080:${API_PORT}
-      - 6969:${SOCKET_PORT}
+      - 127.0.0.1:6969:${SOCKET_PORT}
     env_file:
       - .env
 

--- a/web/frontend/nginx.conf
+++ b/web/frontend/nginx.conf
@@ -18,7 +18,7 @@ http {
         }
 
         location /api/ {
-            proxy_pass http://cerbero-backend:8080;
+            proxy_pass http://cerbero-backend;
         }
     }
 }


### PR DESCRIPTION
# Change docker ports setup

## Changes

1. All `/api` requests from the frontend are proxied to `http://cerbero-backend` on port 80, therefore the `API_PORT` environment variable MUST be set to 80 for now.

2. Bind the tcp socket only to `127.0.0.1` in the `docker-compose` file.