### PR TITLE
Add new documentation and refactor the existing one

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,207 @@
+# contributing
+
+> ⌨️ Contributing guide for the cerbero project.
+
+## Table of contents
+
+<!--toc:start-->
+- [contributing](#contributing)
+  - [Table of contents](#table-of-contents)
+  - [Before contributing](#before-contributing)
+  - [Bootstrapping a development environment](#bootstrapping-a-development-environment)
+    - [Development environment for cerbero-web](#development-environment-for-cerbero-web)
+  - [Workflow](#workflow)
+    - [Branching Strategy](#branching-strategy)
+        - [Create a branch](#create-a-branch)
+        - [Make changes](#make-changes)
+        - [Create a pull request](#create-a-pull-request)
+        - [Merge your pull request](#merge-your-pull-request)
+        - [Delete your branch](#delete-your-branch)
+          - [Checkout into main](#checkout-into-main)
+          - [Pull changes in main](#pull-changes-in-main)
+          - [Delete your branch locally](#delete-your-branch-locally)
+          - [Prune the remote](#prune-the-remote)
+    - [Commit Convention](#commit-convention)
+      - [Commit Message Header](#commit-message-header)
+        - [Type](#type)
+        - [Scope](#scope)
+      - [Commit Message Body](#commit-message-body)
+      - [Commit Message Footer](#commit-message-footer)
+      - [More information about conventional commits](#more-information-about-conventional-commits)
+    - [Pull Requests](#pull-requests)
+      - [When to pull request](#when-to-pull-request)
+    - [Issues](#issues)
+<!--toc:end-->
+
+## Before contributing
+
+No matter if you are a inside `K!nd4SUS` or a random dude that suddenly wants to contribute to this project, before making any change to the codebase, please read this document.
+
+## Bootstrapping a development environment
+
+### Development environment for cerbero-web
+
+If you wish to contribute to cerbero-web, you can follow our [frontend development quick-start guide](/web/frontend/README.md#quick-start) and our [backend development quick-stark guide](/web/backend/README.md#quick-start). You will have a working development environment in no time.
+
+## Workflow
+
+### Branching Strategy
+
+> This project follows the [GitHubFlow](https://docs.github.com/en/get-started/quickstart/github-flow) branching strategy.
+
+Following is a summary of a typical GitHubFlow workflow:
+
+##### Create a branch
+
+Create a branch (from `main`) in your repository. The branch name should be short and descriptive, for example: `increase-test-timeout` or `add-code-of-conduct`.
+
+```sh
+git checkout -b <name_of_the_branch>
+```
+
+If a branch targets a specific issue **the name of the branch should begin with the issue_id** e.g. `123-fix-users-endpoint`.
+
+##### Make changes
+
+On your branch, make the desired changes to the repository, then commit and push your changes to your branch.
+
+When committing your changes, make sure to follow the guidelines described in the <a href="#commits">commits section</a>.
+
+##### Create a pull request
+
+When you create a pull request, **include a summary of the changes** and what problem they solve.
+
+##### Merge your pull request
+
+Once your pull request has been approved, merge your pull request. This will automatically merge your branch so that your changes appear on the default branch.
+
+##### Delete your branch
+
+After you merge your pull request, **delete your branch**. Deleting the branch on GitHub can be done in the branches section of the repository.
+
+To delete your branch locally you can run the following commands:
+
+###### Checkout into main
+
+```sh
+git checkout main
+```
+
+###### Pull changes in main
+
+```sh
+git pull
+```
+
+###### Delete your branch locally
+
+```sh
+git branch -d <name_of_the_branch>
+```
+
+###### Prune the remote
+
+This is **optional** and will remove references to remote branches that were deleted.
+
+```sh
+git remote prune origin
+```
+
+### Commit Convention
+
+> This project follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification, this increases consistency and readability of commits.
+
+> Following is a summary of the conventional commits specification, modified to fit the needs of this project.
+
+Each commit message consists of a **header**, a **body**, and a **footer**.
+
+```
+<header>
+<BLANK LINE>
+<body>
+<BLANK LINE>
+<footer>
+```
+
+#### Commit Message Header
+
+```
+<type>(<scope>): <short summary>
+  │       │             │
+  │       │             └─⫸ Summary in present tense. Not capitalized. No period at the end.
+  │       │
+  │       └─⫸ Commit Scope: components|controllers|db|hooks|middlewares|models|pages|readme|services|utils|<workflow_name>|<test_name>
+  │
+  └─⫸ Commit Type: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test
+```
+
+The `<type>` and `<summary>` fields are mandatory, the `(<scope>)` field is optional.
+
+##### Type
+
+MUST be one of the following:
+
+* **build**: Changes that affect the build system
+* **chore**: Maintain project or external dependencies
+* **ci**: Changes to CI configuration files and scripts
+* **docs**: Documentation only changes
+* **enhance**: A code change that improves an already existing feature
+* **feat**: A code change that adds a new functionality to the application
+* **fix**: A code change that fixes incorrect code (bugs)
+* **perf**: A code change that improves performance
+* **refactor**: A code change that doesn't alter the behaviour of the application
+* **revert**: Revert a previous change
+* **style**: Fix code style, trailing spaces, semi-colons, tab size...
+* **test**: Add missing tests or correct existing ones
+
+##### Scope
+
+The scope is the part of the codebase where the changes happened e.g. `feat(components): create IncredibleButton component`.
+
+- If the change doesn't target any particular scope then the commit scope can be empty e.g. `chore: update beautiful stuff`.
+
+- If a commit changes multiple parts of the codebase then an `*` sign can be used as the scope specifier.
+
+#### Commit Message Body
+
+- Use imperative, present tense: “change” not “changed” nor “changes”.
+
+- Include motivation for the change and contrasts with previous behavior.
+
+#### Commit Message Footer
+
+All breaking changes have to be mentioned in footer with the description of the change, justification and migration notes (e.g. `BREAKING CHANGE: desc...`).
+
+- If a commit targets a specific issue, the issue_id must be specified in the footer e.g. `Closes #123`, in case of multiple issues `Closes #123, #124, #125`.
+
+#### More information about conventional commits
+
+Please take a look at the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification before committing changes.
+
+### Pull Requests
+
+> Pull requests are the final part of this workflow and they allow contributors to **review and share opinions on code** with each other. Furthermore such mechanism opens the doors to **automated workflow runs**.
+
+#### When to pull request
+
+- A pull request should only be opened when the work is *done* and ready for production.
+
+- If a pull request doesn't pass automated testing/linting/building **it shouldn't be merged**: fix the problems and then push your fixes again until it passes.
+
+### Issues
+
+> Issues can be opened for everything that has to do with the project: from asking questions to requesting new fetures or bug-fixes.
+
+Issues should be labeled as follows:
+
+- A `priority` label
+    - `priority: 0` &larr; **Highest**
+    - `priority: 1`
+    - `priority: 2`
+    - `priority: 3`
+    - `priority: 4` &larr; **Lowest**
+- A `scope` label
+    - One of the scopes described in the [commit scope section](#scope).
+- A `type` label
+    - One or more of the types described in the [commit type section](#type).
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@
 
 ## Before contributing
 
-No matter if you are a inside `K!nd4SUS` or a random dude that suddenly wants to contribute to this project, before making any change to the codebase, please read this document.
+No matter if you are a developer inside `K!nd4SUS` or a random dude that suddenly wants to contribute to this project, before making any change to the codebase, please read this document.
 
 ## Bootstrapping a development environment
 

--- a/README.md
+++ b/README.md
@@ -1,30 +1,48 @@
-# Cerbero - A packet filtering tool
+# cerbero
+
+> A packet filtering tool for A/D CTFs.
 
 ![GitHub_banner](https://user-images.githubusercontent.com/23193188/142950155-5d2e00a6-7c9f-42db-9cdf-e28783e66f30.gif)
 
----
-### Description
-This tool is able to filter packets based on the payload by using regex.
+## Table of contents
 
-### Why this tool?
+<!--toc:start-->
+- [cerbero](#cerbero)
+  - [Table of contents](#table-of-contents)
+  - [Intro](#intro)
+    - [Why this tool](#why-this-tool)
+    - [Is it against the rules to use this tool](#is-it-against-the-rules-to-use-this-tool)
+  - [Structure of the project](#structure-of-the-project)
+  - [Usage](#usage)
+  - [Contributing](#contributing)
+<!--toc:end-->
+
+## Intro
+
+This tool is able to filter packets based on their payload by using regular expressions.
+
+### Why this tool
+
 During an A/D, we often had to drop some malicious packets, but to do it properly we had to understand how the service worked and in which programming language it was written. This process is a waste of time. With this tool we can instead drop the malicious packets before they are received from the vulnerable service, making the process simple and implementation agnostic (basically it works like a WAF that process all packets).
 
-### Is it against the rules to use this tool? 
+### Is it against the rules to use this tool
+
 Probably not, but we do not take any responsibility for its use.
 
----
+## Structure of the project
 
-### How to use the tool
+This hyper-professional diagram represents on a conceptual level how this tool is structured:
 
-`⚠️ The program need root permission to run ⚠️`
+![diagram](https://github.com/K1nd4SUS/cerbero/assets/78105813/35df3ed1-a460-4fa3-ba79-fe169b622477)
 
-You can download the last resease from [here](https://github.com/K1nd4SUS/Cerbero/releases)
+## Usage
 
-```
-Usage of ./cerbero:
-  -chain string
-        Input chain name. (default "INPUT")
-  -config string
-        Relative or absolute path to the JSON configuration file. (default "./config.json")
-  -v    Enable DEBUG-level logging.
-```
+1. [Deploy cerbero-web with docker compose](/web/README.md#deployment-with-docker-compose)
+2. [Download the cerbero binary on the vuln-box](/firewall/README.md#download-the-binary-on-the-vuln-box)
+
+**Warning: cerbero-web must be set up before trying to connect the firewall**, this means that *before starting the `cerbero` binary* you MUST complete the services setup on cerbero-web.
+
+## Contributing
+
+If you wish to contribute to the project, make sure to read the [contributing](/CONTRIBUTING.md) guide first.
+

--- a/firewall/README.md
+++ b/firewall/README.md
@@ -1,0 +1,62 @@
+# cerbero-firewall
+
+## Table of contents
+
+<!--toc:start-->
+- [cerbero-firewall](#cerbero-firewall)
+  - [Table of contents](#table-of-contents)
+  - [Users documentation](#users-documentation)
+    - [Deploy](#deploy)
+      - [Download the binary on the vuln-box](#download-the-binary-on-the-vuln-box)
+    - [Usage](#usage)
+      - [Run with config file](#run-with-config-file)
+      - [Run with socket](#run-with-socket)
+      - [Help](#help)
+<!--toc:end-->
+
+## Users documentation
+
+### Deploy
+
+#### Download the binary on the vuln-box
+
+You can download the latest resease from [here](https://github.com/K1nd4SUS/cerbero/releases).
+
+### Usage
+
+**Warning: The `cerbero` binary needs `root` privileges to run.**
+
+#### Run with config file
+
+The binary can get the configuration from a `json` file (see [config.json](/firewall/config.json) as an example).
+
+```sh
+cerbero file <path_to_config> [...options]
+```
+
+*The `file` mode is more suited for development/debugging.*
+
+#### Run with socket
+
+When used in conjunction with cerbero-web, you must run the binary in `socket` mode and specify the correct socket `address:port` pair.
+
+```sh
+cerbero socket <socket_address:socket_port> [...options]
+```
+
+For example, if in cerbero-web (deployed on the same machine as the binary) you decided to run the TCP socket server on port `1234` (specified in the `.env` file by the `SOCKET_PORT` variable) this command will do the job:
+
+```sh
+cerbero socket localhost:1234
+```
+
+*The `socket` mode is the preferred way to run cerbero in an A/D CTF.*
+
+#### Help
+
+You can find more in-depth information about the commands and flags in the help menu:
+
+```sh
+cerbero -h
+```
+

--- a/web/README.md
+++ b/web/README.md
@@ -1,17 +1,26 @@
 # cerbero-web
 
+> 🌐 Web-based control panel for cerbero.
+
+## Table of contents
+
 <!--toc:start-->
 - [cerbero-web](#cerbero-web)
-  - [Deploy](#deploy)
-    - [Environment variables](#environment-variables)
-    - [Start the containers](#start-the-containers)
+  - [Table of contents](#table-of-contents)
+  - [Users documentation](#users-documentation)
+    - [Deployment with docker compose](#deployment-with-docker-compose)
+      - [Environment variables](#environment-variables)
+      - [Start the containers](#start-the-containers)
+  - [Developers documentation](#developers-documentation)
+    - [Develop the frontend](#develop-the-frontend)
+    - [Develop the backend](#develop-the-backend)
 <!--toc:end-->
 
-> Web-based control panel for cerbero.
+## Users documentation
 
-## Deploy
+### Deployment with docker compose
 
-### Environment variables
+#### Environment variables
 
 Create a `.env` file from the `.template.env`:
 
@@ -19,9 +28,7 @@ Create a `.env` file from the `.template.env`:
 cp .template.env .env
 ```
 
-Fill the `.env` file with the desired values:
-
-Example:
+Fill the `.env` file with the following values:
 
 ```
 API_PORT="80"
@@ -29,9 +36,19 @@ REDIS_URL="redis://cerbero-redis-stack:6379"
 SOCKET_PORT="6969"
 ```
 
-### Start the containers
+#### Start the containers
 
 ```sh
 docker compose up -d
 ```
+
+## Developers documentation
+
+### Develop the frontend
+
+You can find more information about the frontend [here](/web/frontend/README.md#developers-documentation).
+
+### Develop the backend
+
+You can find more information about the backend [here](/web/backend/README.md#developers-documentation).
 

--- a/web/backend/README.md
+++ b/web/backend/README.md
@@ -1,68 +1,97 @@
 # cerbero-backend
 
-> 📦 Backend of cerbero packet filtering tool.
+> 📦 Backend of cerbero-web.
 
 ## Table of contents
 
-1. [ Documentation ](#documentation)
-    - [ Quick start ](#quick-start)
-    - [ Build ](#build)
-    - [ Environment variables ](#environment-variables)
-2. [ Workflow ](#workflow)
-    - [ Branching Strategy ](#branching-strategy)
-        - [ Create a branch ](#create-a-branch)
-        - [ Make changes ](#make-changes)
-        - [ Create a PR ](#create-a-pull-request)
-        - [ Delete your branch ](#delete-your-branch)
-    - [ Commit Convention ](#commit-convention)
-        - [ Commit message header ](#commit-message-header)
-            - [ Type ](#type)
-            - [ Scope ](#scope)
-        - [ Commit message body ](#commit-message-body)
-        - [ Commit message footer ](#commit-message-footer)
-    - [ Issues ](#issues)
-    - [ Pull Requests ](#pull-requests)
-        - [ When to pull request ](#when-to-pull-request)
+<!--toc:start-->
+- [cerbero-backend](#cerbero-backend)
+  - [Table of contents](#table-of-contents)
+  - [Developers documentation](#developers-documentation)
+    - [Quick start](#quick-start)
+      - [Install the required `node_modules` for development](#install-the-required-nodemodules-for-development)
+      - [Create a `.env` file](#create-a-env-file)
+      - [Start a redis-stack instance](#start-a-redis-stack-instance)
+      - [Start the development server](#start-the-development-server)
+    - [Build](#build)
+      - [Install the required `node_modules` for building](#install-the-required-nodemodules-for-building)
+      - [Compile the source into javascript](#compile-the-source-into-javascript)
+      - [Finally start the compiled source with](#finally-start-the-compiled-source-with)
+    - [Environment variables](#environment-variables)
+      - [`API_PORT`](#apiport)
+      - [`REDIS_URL`](#redisurl)
+      - [`SOCKET_PORT`](#socketport)
+<!--toc:end-->
 
-## Documentation
+## Developers documentation
 
 ### Quick start
 
-> To setup a development server run the following commands:
+> The following commands **must** be executed inside the `web/backend/` directory.
 
-I highly suggest to use node version `18.17.x`, you can quickly swap between node versions with [`nvm`](https://github.com/nvm-sh/nvm) (node version manager).
+*Make sure to be on node version `18.17.1`, you can quickly swap between node versions with [`nvm`](https://github.com/nvm-sh/nvm) (node version manager).*
 
-Install all the required `node_modules`:
+#### Install the required `node_modules` for development
 
 ```sh
 npm i
 ```
 
-Start the development server (nodemon with ts-node):
+#### Create a `.env` file
+
+> The `.env` file **must** be located inside the `web/backend/` directory (`web/backend/.env`).
+
+Fill the `.env` with the following values:
+
+```sh
+API_PORT="6666"
+REDIS_URL="redis://localhost:6379"
+SOCKET_PORT="6969"
+```
+
+**Currently the `API_PORT` value MUST be `6666` because in the development phase `/api` requests are proxied only to that port (it is hardcoded in `vite.config.ts`)**
+
+#### Start a redis-stack instance
+
+One of the easiest ways to bootstrap a redis-stack instance is running it with docker:
+
+```sh
+docker run -d -p "127.0.0.1:6379:6379" --name cerbero-redis-stack-dev redis/redis-stack:latest
+```
+
+#### Start the development server
 
 ```sh
 npm run dev
 ```
 
-### Build
-
-> The build process consists in compiling the typescript code into javascript, the compiled source will be stored into the `dist` directory.
-
-> The requirements for the build process are the `package.json` file and the source (`src`).
-
-Install **only** the production dependencies:
+If you have done everything correctly you should be able to see something like this in your terminal:
 
 ```sh
-npm i --omit=dev
+2012-12-12T12:00:00.000Z [INFO] API listening on port 6666
+2012-12-12T12:00:00.000Z [INFO] Socket server listening on port 6969
+2012-12-12T12:00:00.000Z [INFO] Connected to db redis://localhost:6379
 ```
 
-Compile the source into javascript:
+### Build
+
+> The build process consists in compiling the typescript code into javascript, the compiled source will be stored into the `dist/` directory.
+
+*Most of the times you won't need to build anything manually, we use automated CI pipelines to handle that for us.*
+
+#### Install the required `node_modules` for building
+
+```sh
+npm i
+```
+
+#### Compile the source into javascript
 
 ```sh
 npm run build
 ```
 
-Finally start the compiled source with:
+#### Finally start the compiled source with
 
 ```
 npm run start
@@ -78,127 +107,7 @@ This variable is **mandatory** and specifies the port where the express api will
 
 This variable is **mandatory** and specifies the redis connection string that the api will use to connect to the database.
 
-## Workflow
+#### `SOCKET_PORT`
 
-### Branching Strategy
+This variable is **mandatory** and specifies the port where the TCP socket server will start listening for connections.
 
-> This project follows the [GitHubFlow](https://docs.github.com/en/get-started/quickstart/github-flow) branching strategy.
-
-> Following is a summary of a typical GitHubFlow workflow.
-
-##### Create a branch
-
-Create a branch in your repository. The branch name should be short and descriptive, for example: `increase-test-timeout` or `add-code-of-conduct`.
-
-- If a branch targets a specific issue **the name of the branch should begin with the issue_id** e.g. `123-fix-users-endpoint`.
-
-##### Make changes
-
-On your branch, make the desired changes to the repository, then commit and push your changes to your branch.
-
-When committing your changes, make sure to follow the guidelines described in the <a href="#commits">commits section</a>.
-
-##### Create a pull request
-
-When you create a pull request, **include a summary of the changes** and what problem they solve.
-
-##### Merge your pull request
-
-Once your pull request is approved, merge your pull request. This will automatically merge your branch so that your changes appear on the default branch.
-
-##### Delete your branch
-
-After you merge your pull request, **delete your branch**.
-
-### Commit Convention
-
-> This project follow the [AngularJS commit-message convention](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#-commit-message-format), this increases consistency and readability of commits but more importantly it eases the creation of version numbers.
-
-> Following is a summary of the conventional commits strategy, modified to fit the needs of this project.
-
-Each commit message consists of a **header**, a **body**, and a **footer**.
-
-```
-<header>
-<BLANK LINE>
-<body>
-<BLANK LINE>
-<footer>
-```
-
-#### Commit Message Header
-
-```
-<type>(<scope>): <short summary>
-  │       │             │
-  │       │             └─⫸ Summary in present tense. Not capitalized. No period at the end.
-  │       │
-  │       └─⫸ Commit Scope: components|controllers|db|hooks|middlewares|models|pages|readme|services|utils|<workflow_name>|<test_name>
-  │
-  └─⫸ Commit Type: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test
-```
-
-The `<type>` and `<summary>` fields are mandatory, the `(<scope>)` field is optional.
-
-##### Type
-
-Must be one of the following:
-
-* **build**: Changes that affect the build system
-* **chore**: Maintain project or external dependencies
-* **ci**: Changes to CI configuration files and scripts
-* **docs**: Documentation only changes
-* **feat**: A code change that adds a new functionality to the application
-* **fix**: A code change that fixes incorrect code
-* **perf**: A code change that improves performance
-* **refactor**: A code change that doesn't alter the behaviour of the application
-* **revert**: Revert a previous change
-* **style**: Fix code style, trailing spaces, semi-colons, tab size...
-* **test**: Add missing tests or correct existing ones
-
-##### Scope
-
-The scope is the part of the codebase where the changes happened e.g. `feat(components): create IncredibleButton component`.
-
-- If the change doesn't target any particular scope then the commit scope can be empty e.g. `chore: update beautiful stuff`.
-
-- If a commit changes multiple parts of the codebase then an `*` sign can be used as the scope specifier.
-
-#### Commit Message Body
-
-- Use imperative, present tense: “change” not “changed” nor “changes”.
-
-- Include motivation for the change and contrasts with previous behavior.
-
-#### Commit Message Footer
-
-All breaking changes have to be mentioned in footer with the description of the change, justification and migration notes (e.g. `BREAKING CHANGE: desc...`).
-
-- If a commit targets a specific issue, the issue_id must be specified in the footer e.g. `Closes #123`, in case of multiple issues `Closes #123, #124, #125`.
-
-### Issues
-
-> Issues can be opened for everything that has to do with the program, from asking questions to requesting new fetures or bug-fixes.
-
-Issues should describe and include each of the following components:
-
-- A `priority` label
-    - `priority: 0` &larr; **Highest**
-    - `priority: 1`
-    - `priority: 2`
-    - `priority: 3`
-    - `priority: 4` &larr; **Lowest**
-- A `scope` label
-    - One of the scopes described in the [commit scope section](#scope).
-- A `type` label
-    - One of the types described in the [commit type section](#type).
-
-### Pull Requests
-
-> Pull requests are the final part of this workflow and they allow contributors to **review and share opinions on code** with each other. Furthermore such mechanism opens the doors to **automated workflow runs** (continuous integration).
-
-#### When to pull request
-
-- A pull request should only be opened when the work is *done* and ready for production.
-
-- If a pull request doesn't pass every automated test, **it shouldn't be merged**, fix the problems and then push your fixes again until it passes.

--- a/web/frontend/README.md
+++ b/web/frontend/README.md
@@ -1,3 +1,61 @@
 # cerbero-frontend
 
-> 📦 Frontend of cerbero packet filtering tool.
+> 📦 Frontend of cerbero-web.
+
+## Table of contents
+
+<!--toc:start-->
+- [cerbero-frontend](#cerbero-frontend)
+  - [Table of contents](#table-of-contents)
+  - [Developers documentation](#developers-documentation)
+    - [Quick start](#quick-start)
+      - [Install the required `node_modules` for development](#install-the-required-nodemodules-for-development)
+      - [Start the development server](#start-the-development-server)
+    - [Build](#build)
+      - [Install the required `node_modules` for building](#install-the-required-nodemodules-for-building)
+      - [Compile the source into javascript](#compile-the-source-into-javascript)
+      - [Finally preview the compiled source with](#finally-preview-the-compiled-source-with)
+<!--toc:end-->
+
+## Developers documentation
+
+### Quick start
+
+> The following commands **must** be executed inside the `web/frontend/` directory.
+
+#### Install the required `node_modules` for development
+
+```sh
+npm i
+```
+
+#### Start the development server
+
+```sh
+npm run dev
+```
+
+### Build
+
+> The build process consists in compiling the typescript code into javascript, the compiled source will be stored into the `dist/` directory.
+
+*Most of the times you won't need to build anything manually, we use automated CI pipelines to handle that for us.*
+
+#### Install the required `node_modules` for building
+
+```sh
+npm i
+```
+
+#### Compile the source into javascript
+
+```sh
+npm run build
+```
+
+#### Finally preview the compiled source with
+
+```
+npm run preview
+```
+


### PR DESCRIPTION
# Add new documentation and refactor the existing one

## Changes

- Create `CONTRIBUTING.md` (guidelines for both internal and external developers).
- Split documentation (and add new documentation) in multiple README files (`README.md`, `firewall/README.md`, `web/README.md`, `web/frontend/README.md`, `web/backend/README.md`).