### PR TITLE
fix(firewall): support for PCRE regex syntax

### DIFF
--- a/firewall/go.mod
+++ b/firewall/go.mod
@@ -5,6 +5,7 @@ go 1.21.4
 require (
 	github.com/alecthomas/kong v0.8.1
 	github.com/coreos/go-iptables v0.7.0
+	github.com/dlclark/regexp2 v1.11.4
 	github.com/florianl/go-nfqueue v1.3.1
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/prometheus/client_golang v1.17.0

--- a/firewall/go.sum
+++ b/firewall/go.sum
@@ -12,6 +12,8 @@ github.com/coreos/go-iptables v0.7.0 h1:XWM3V+MPRr5/q51NuWSgU0fqMad64Zyxs8ZUoMsa
 github.com/coreos/go-iptables v0.7.0/go.mod h1:Qe8Bv2Xik5FyTXwgIbLAnv2sWSBmvWdFETJConOQ//Q=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dlclark/regexp2 v1.11.4 h1:rPYF9/LECdNymJufQKmri9gV604RvvABwgOA8un7yAo=
+github.com/dlclark/regexp2 v1.11.4/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/florianl/go-nfqueue v1.3.1 h1:khQ9fYCrjbu5CF8dZF55G2RTIEIQRI0Aj5k3msJR6Gw=
 github.com/florianl/go-nfqueue v1.3.1/go.mod h1:aHWbgkhryJxF5XxYvJ3oRZpdD4JP74Zu/hP1zuhja+M=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=


### PR DESCRIPTION
This PR adds support for PCRE regexes, and removes it for RE2 regexes. This means that the regexes are now compatible with Python, PERL, etc. and regexes like the following will now work:
```regex
^(?!2\.25\.1$).*
```

Moreover, whenever a regex compile fails, it now logs it instead of crashing the firewall.