### PR TITLE
fix(firewall): change debug log to better reflect what the firewall is doing

### DIFF
--- a/firewall/services/services.go
+++ b/firewall/services/services.go
@@ -267,5 +267,5 @@ func CompileMatchers() {
 		}
 	}
 
-	logs.PrintDebug("Compiled regex matchers...")
+	logs.PrintDebug("Compiled regex matchers.")
 }


### PR DESCRIPTION
This PR fixes a small debug text that would originally notify it's still performing some actions while it's actually not.